### PR TITLE
added optin to disable icon tinting in iOS TabBar

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -146,17 +146,32 @@
         UIImage *iconImage = nil;
         id icon = tabItemLayout[@"props"][@"icon"];
         if (icon) {
-            iconImage = [RCTConvert UIImage:icon];
-            if (buttonColor) {
-                iconImage = [[self image:iconImage withColor:buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+            BOOL disableIconTint = [[RCCManager sharedInstance] getAppStyle][@"tabBarDisableIconTint"];
+            if (disableIconTint) {
+                iconImage = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+            } else {
+                iconImage = [RCTConvert UIImage:icon];
+                if (buttonColor)
+                {
+                    iconImage = [[self image:iconImage withColor:buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+                }
             }
         }
         UIImage *iconImageSelected = nil;
         id selectedIcon = tabItemLayout[@"props"][@"selectedIcon"];
+        BOOL disableSelectedIconTint = [[RCCManager sharedInstance] getAppStyle][@"tabBarDisableSelectedIconTint"];
         if (selectedIcon) {
-            iconImageSelected = [RCTConvert UIImage:selectedIcon];
+            if (disableSelectedIconTint) {
+                iconImageSelected = [[RCTConvert UIImage:selectedIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+            } else {
+                iconImageSelected = [RCTConvert UIImage:selectedIcon];
+            }
         } else {
-            iconImageSelected = [RCTConvert UIImage:icon];
+            if (disableSelectedIconTint) {
+                iconImageSelected = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+            } else {
+                iconImageSelected = [RCTConvert UIImage:icon];
+            }
         }
         
         viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:title image:iconImage tag:0];
@@ -292,15 +307,24 @@
             UIImage *iconImage = nil;
             id icon = actionParams[@"icon"];
             if (icon && icon != (id)[NSNull null]) {
-                iconImage = [RCTConvert UIImage:icon];
-                iconImage = [[self image:iconImage withColor:self.tabBar.tintColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+                BOOL disableIconTint = [[RCCManager sharedInstance] getAppStyle][@"tabBarDisableIconTint"];
+                if (disableIconTint) {
+                    iconImage = [[RCTConvert UIImage:icon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+                } else {
+                    iconImage = [RCTConvert UIImage:icon];
+                }
                 viewController.tabBarItem.image = iconImage;
             }
             
             UIImage *iconImageSelected = nil;
             id selectedIcon = actionParams[@"selectedIcon"];
             if (selectedIcon && selectedIcon != (id)[NSNull null]) {
-                iconImageSelected = [RCTConvert UIImage:selectedIcon];
+                BOOL disableSelectedIconTint = [[RCCManager sharedInstance] getAppStyle][@"tabBarDisableSelectedIconTint"];
+                if (disableSelectedIconTint) {
+                    iconImageSelected = [[RCTConvert UIImage:selectedIcon] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+                } else {
+                    iconImageSelected = [RCTConvert UIImage:selectedIcon];
+                }
                 viewController.tabBarItem.selectedImage = iconImageSelected;
             }
             


### PR DESCRIPTION
This PR merges code from <> which adds the following options:

```
appStyle: {
...
tabBarDisableIconTint: true,
tabBarDisableSelectedIconTint: true
}
```

This let's us disable tinting of icons and instead use the supplied `active` and `inactive` icons. This does not work on Android though and needs to be resolved by the ReactNativeNavigation team.

Reference PRs on upstream project:

1. https://github.com/wix/react-native-navigation/pull/1943 
2. https://github.com/wix/react-native-navigation/pull/1978/files